### PR TITLE
Use .empty() where appropriate

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -74,7 +74,7 @@ struct DST {
   DST(std::string skipped, std::string repeated):
     skipped(parse_dst_roll(skipped)), repeated(parse_dst_roll(repeated)) {}
   DST(const cpp11::strings roll_dst) {
-    if (roll_dst.size() == 0 || roll_dst.size() > 2)
+    if (roll_dst.empty() || roll_dst.size() > 2)
       Rf_error("roll_dst must be a character vector of length 1 or 2");
     std::string dst_repeated(roll_dst[0]);
     skipped = parse_dst_roll(dst_repeated);

--- a/src/tzone.cpp
+++ b/src/tzone.cpp
@@ -52,7 +52,7 @@ const char* local_tz() {
 
 bool load_tz(std::string tzstr, cctz::time_zone& tz) {
   // return `true` if loaded, else false
-  if (tzstr.size() == 0) {
+  if (tzstr.empty()) {
     // CCTZ doesn't work on windows https://github.com/google/cctz/issues/53
     /* std::cout << "Local TZ: " << local_tz() << std::endl; */
     return cctz::load_time_zone(local_tz(), &tz);

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -33,7 +33,7 @@ cpp11::writable::doubles C_time_update(const cpp11::doubles dt,
                                        const int week_start = 1,
                                        const bool exact = false) {
 
-  if (dt.size() == 0)
+  if (dt.empty())
     // FIXME: ignored tz argument
     return(posixct(tz_from_tzone_attr(dt)));
 


### PR DESCRIPTION
https://releases.llvm.org/5.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html