### PR TITLE
sync parameter names in header vs. implementation

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -90,9 +90,9 @@ struct DST {
 // Helper for conversion functions. Get seconds from civil_lookup, but relies on
 // original time pre/post time if cl_new falls in repeated interval.
 double civil_lookup_to_posix(const cctz::time_zone::civil_lookup& cl_new, // new lookup
-                             const cctz::time_zone& tz_orig,              // original time zone
-                             const time_point& tp_orig,                   // original time point
-                             const cctz::civil_second& cs_orig,           // original time in secs
+                             const cctz::time_zone& tz_old,               // original time zone
+                             const time_point& tp_old,                    // original time point
+                             const cctz::civil_second& cs_old,            // original time in secs
                              const DST& dst,
                              const double remainder) noexcept;
 


### PR DESCRIPTION
i.e. here:

https://github.com/vspinu/timechange/blob/32d9c5ba5ec700c971d6a3f800510f629680b77c/src/common.cpp#L47-L52