### PR TITLE
Use Date's tz() when converting with to_posixct()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -33,7 +33,7 @@ to_posixct <- function(time) {
     storage.mode(time) <- "double"
     time
   } else if (is.Date(time))
-    date_to_posixct(time)
+    date_to_posixct(time, tz = tz(time))
   else if (is.POSIXlt(time)) {
     as.POSIXct.POSIXlt(time, tz = tz(time))
   } else {


### PR DESCRIPTION
## Issue

Currently, `to_posixct()` assumes `tz = "UTC"` when converting a `Date` type.  However, `tz()` checks for the `"tzone"` attribute.  It is possible to run into dates with the `"tzone"` attribute and this can lead to unexpected results from `to_posixct()`

Example of unexpected results when using `time_floor()`:

```r
# Create a date with tzone attribute
x <- as.Date("2020-01-01")
attr(x, "tzone") <- "America/New_York"

packageVersion("timechange")
# [1] ‘0.1.1.9000’

# This version assumes date to be UTC in
# the `date_to_posixct()` conversion
timechange::time_floor(x, "months", 1)
# [1] "2019-12-31"
```

## Proposed fix

Change `to_posixct()`'s call to `date_to_posixct()` to use `tz(time)` instead of assuming UTC.  If the Date doesn't have a `"tzone"` attribute UTC will still be the default.

```r
# after changing to_posixct() usage of date_to_posixct to:
# date_to_posixct(time, tz = tz(time))
timechange::time_floor(x, "months", 1)
# [1] "2020-01-01"
```